### PR TITLE
Use standard library internal bigarray

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ocp-sha.cma: src/SHA.mli src/SHA.ml
 	ocamlc -I src -a $^ -o $@
 
 ocp-sha: ocp-sha.cmxa src/ocp_sha_main.ml
-	ocamlopt -I src unix.cmxa bigarray.cmxa $^ -o $@
+	ocamlopt -I src unix.cmxa $^ -o $@
 
 test-init:
 	rm -rf test


### PR DESCRIPTION
- As per https://caml.inria.fr/pub/docs/manual-ocaml/libbigarray.html ,
  the `bigarray` library is now in the OCaml standard library
- Use `Unix.map_file`
- Use bytes explicitly instead of strings